### PR TITLE
Hand duplicate of mime type array to MIME::Types.from_array

### DIFF
--- a/lib/heel/mime_map.rb
+++ b/lib/heel/mime_map.rb
@@ -50,7 +50,7 @@ module Heel
     def initialize
       MimeMap.additional_mime_types.each do |mt|
         if MIME::Types[mt.first].size == 0 then
-          type = MIME::Type.from_array(mt)
+          type = MIME::Type.from_array(mt.dup)
           MIME::Types.add(type)
         else
           type = MIME::Types[mt.first].first


### PR DESCRIPTION
Since from_array uses the array destructively, give it its own private
copy to do with it as it pleases.

This fixes #11
