### PR TITLE
URL-escape links to handle "weird" filenames

### DIFF
--- a/lib/heel/directory_indexer.rb
+++ b/lib/heel/directory_indexer.rb
@@ -4,6 +4,7 @@
 #++
 
 require 'erb'
+require 'cgi'
 
 module Heel
   # generate html index pages of a directory
@@ -66,7 +67,7 @@ module Heel
         entry_data      = OpenStruct.new 
 
         entry_data.name          = entry == ".." ? "Parent Directory" : entry
-        entry_data.link          = entry
+        entry_data.link          = CGI.escape(entry)
         entry_data.size          = num_to_bytes(stat.size)
         entry_data.last_modified = stat.mtime.strftime("%Y-%m-%d %H:%M:%S")
 


### PR DESCRIPTION
I had some trouble with files containing the #-character. URL-escaping the link should avoid problems with unusual file names.
