### PR TITLE
add dependency on rack

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ This.email    = "jeremy@copiousfreetime.org"
 This.homepage = "http://github.com/copiousfreetime/#{ This.name }"
 
 This.ruby_gemspec do |spec|
+  spec.add_runtime_dependency( 'rack'      , '~> 2.0' )
   spec.add_runtime_dependency( 'puma'      , '~> 2.0' )
   spec.add_runtime_dependency( 'mime-types', '~> 1.25')
   spec.add_runtime_dependency( 'launchy'   , '~> 2.3' )


### PR DESCRIPTION
`lib/heel/rackapp.rb` depends on rack but it's not in the gemspec. This fixes that!

I did not run the tests. They're broken on 2.5.0. Looks like they finally took `ubygems.rb` away.

